### PR TITLE
Don't send `update_track_metadata` ME before `sdpOffer` ME

### DIFF
--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -175,7 +175,10 @@ class TrackContextImpl implements TrackContext {
   onEncodingChanged?: (this: TrackContext) => void;
   onVoiceActivityChanged?: (this: TrackContext) => void;
   negotiationStatus: TrackNegotiationStatus = "awaiting";
-  metadataUpdatePending: boolean = false;
+
+  // Indicates that metadata were changed when in "offered" negotiationStatus
+  // and `updateTrackMetadata` Media Event should be sent after the transition to "done"
+  pendingMetadataUpdate: boolean = false;
 
   constructor(peer: Peer, trackId: string, metadata: any) {
     this.peer = peer;
@@ -476,7 +479,7 @@ export class MembraneWebRTC {
           if (track) {
             track.negotiationStatus = "done";
 
-            if (track.metadataUpdatePending) {
+            if (track.pendingMetadataUpdate) {
               const mediaEvent = generateMediaEvent("updateTrackMetadata", {
                 trackId,
                 metadata: track.metadata,
@@ -484,7 +487,7 @@ export class MembraneWebRTC {
               this.sendMediaEvent(mediaEvent);
             }
 
-            track.metadataUpdatePending = false;
+            track.pendingMetadataUpdate = false;
           }
         }
 
@@ -1179,7 +1182,7 @@ export class MembraneWebRTC {
         break;
 
       case "offered":
-        trackContext.metadataUpdatePending = true;
+        trackContext.pendingMetadataUpdate = true;
         break;
 
       case "awaiting":

--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -172,6 +172,7 @@ class TrackContextImpl implements TrackContext {
   vadStatus: VadStatus = "silence";
   onEncodingChanged?: (this: TrackContext) => void;
   onVoiceActivityChanged?: (this: TrackContext) => void;
+  isOffered: boolean = false;
 
   constructor(peer: Peer, trackId: string, metadata: any) {
     this.peer = peer;
@@ -1143,11 +1144,14 @@ export class MembraneWebRTC {
     this.localTrackIdToTrack.set(trackId, trackContext);
 
     this.localPeer.trackIdToMetadata.set(trackId, trackMetadata);
-    let mediaEvent = generateMediaEvent("updateTrackMetadata", {
-      trackId,
-      trackMetadata,
-    });
-    this.sendMediaEvent(mediaEvent);
+
+    if (trackContext.isOffered) {
+      let mediaEvent = generateMediaEvent("updateTrackMetadata", {
+        trackId,
+        trackMetadata,
+      });
+      this.sendMediaEvent(mediaEvent);
+    }
   };
 
   private getMidToTrackId = () => {
@@ -1257,6 +1261,10 @@ export class MembraneWebRTC {
         },
       });
       this.sendMediaEvent(mediaEvent);
+
+      for (let track of this.localTrackIdToTrack.values()) {
+        track.isOffered = true;
+      }
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
A bug was discovered when the server received an `update_track_metadata` request on a track it wasn't aware of.
The issue is caused by the fact that `addTrack` doesn't wait for the track to be actually fully added - it sends `renegotiate_tracks` ME, but metadata are sent with `sdpOffer` media event!
If `updateTrackMetadata` function is called before `sdpOff` ME is sent, the server doesn't yet know that that track exists.

As a solution, a flag was added to `TrackContextImpl` informing if the track is awaiting to be offered, has been offered and we're awaiting an answer and that the negotiation is completed and the server is fully aware of it.
Every call to `updateTrackMetadata` before it was offered will only result in `TrackContextImpl` being updated, without sending a media event.
We should consider if there are other cases when it could break in simmilar fashion.

This bug blocks the update to newest version of `membrane_rtc_engine` in Videoroom, so it is of the highest priority