### PR TITLE
Set bundlePolicy to "max-bundle"

### DIFF
--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -328,6 +328,7 @@ export class MembraneWebRTC {
   private midToTrackId: Map<string, string> = new Map();
   private disabledTrackEncodings: Map<string, TrackEncoding[]> = new Map();
   private rtcConfig: RTCConfiguration = {
+    bundlePolicy: "max-bundle",
     iceServers: [],
     iceTransportPolicy: "relay",
   };


### PR DESCRIPTION
Since our Engine is BUNDLE-aware, there's no need for the browser to try creating candidates for each media. "max-bundle" will enforce the assumption of BUNDLE-aware endpoint and prevent creating extra allocation on our fake TURN

Reference for `bundlePolicy`: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection