### PR TITLE
Disable track stopping

### DIFF
--- a/src/membraneWebRTC.ts
+++ b/src/membraneWebRTC.ts
@@ -1234,7 +1234,6 @@ export class MembraneWebRTC {
       this.connection.oniceconnectionstatechange = null;
     }
 
-    this.localTracksWithStreams.forEach(({ track }) => track.stop());
     this.localTracksWithStreams = [];
     this.connection = undefined;
   };


### PR DESCRIPTION
The library should only manage its internal state and not manipulate the input stream provided by the user.