### PR TITLE
[RTC-117] Move typed emitter to runtime deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@jellyfish-dev/membrane-webrtc-js",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jellyfish-dev/membrane-webrtc-js",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "Apache-2.0",
       "dependencies": {
         "events": "^3.3.0",
+        "typed-emitter": "^2.1.0",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -18,7 +19,6 @@
         "eslint": "^7.21.0",
         "prettier": "^2.2.1",
         "rimraf": "^3.0.2",
-        "typed-emitter": "^2.1.0",
         "typedoc": "^0.23.0",
         "typescript": "^4.9.4"
       }
@@ -1083,7 +1083,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
       "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -1257,7 +1256,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
-      "dev": true,
       "optional": true
     },
     "node_modules/type-check": {
@@ -1288,7 +1286,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
       "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "dev": true,
       "optionalDependencies": {
         "rxjs": "*"
       }

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "eslint": "^7.21.0",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
-    "typed-emitter": "^2.1.0",
     "typedoc": "^0.23.0",
     "typescript": "^4.9.4"
   },
   "dependencies": {
     "events": "^3.3.0",
+    "typed-emitter": "^2.1.0",
     "uuid": "^8.3.2"
   }
 }


### PR DESCRIPTION
Shouldn't TypedEmitter be in runtime deps? I can see that it's in dev deps in ts-client-sdk but when it's in dev deps, VSCode cannot see `on` property on WebRTCEndpoint class :thinking: 